### PR TITLE
NetStim no longer accepts MCellRan4 generator

### DIFF
--- a/col.hoc
+++ b/col.hoc
@@ -160,7 +160,8 @@ proc nsstim () { local a,sy,sdx,idx,sglo,sghi,hzlo,hzhi,ct,se localobj rdm,vsy,v
         rsl.append( rds = new Random() )
         rds.negexp(1) // set random # generator using negexp(1) - avg interval in NetStim.interval
         rds.MCellRan4(se,se)  // seeds are in order, shouldn't matter
-        ns.noiseFromRandom(rds) // use random # generator for this NetStim
+        // ns.noiseFromRandom(rds) // use random # generator for this NetStim
+        ns.noiseFromRandom123(se, se, 0) // compatible back to 2016
         vrse.append(se) // save random # seed
 
         ncl.append( nc = new NetCon(ns,col.ce.o(idx)) ) // set the connection (netstim->postsynaptic INTF6 cell)

--- a/readme.txt
+++ b/readme.txt
@@ -76,3 +76,4 @@ http://www.frontiersin.org/Computational_Neuroscience/10.3389/fncom.2011.00019/a
          hashseed2 argument.
 20230420 Updated MOD files for compatibility with the new data
          structures in the upcoming version 9.0 of NEURON.
+20240226 Use noiseFromRandom123 for result identity between 8.2 and 9.0


### PR DESCRIPTION
This should produce same results from NEURON 7 onward. 